### PR TITLE
Docker for local development

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM jekyll/jekyll
 WORKDIR /srv/
 RUN gem install bundler
 
-COPY . .
+COPY . . # Note: content folder is copied, only to be replaced later.
 RUN chmod a+w Gemfile.lock
 RUN bundle install
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,12 @@
 FROM jekyll/jekyll
+
+WORKDIR /srv/
+RUN gem install bundler
+
 COPY . .
-RUN [ "bundle", "install", "--path", "vendor/bundle"]
-RUN [ "bundle", "exec", "jekyll", "serve" ]    
+RUN ["chmod", "a+w", "Gemfile.lock"]
+RUN bundle install
+
+EXPOSE 4000
+
+CMD jekyll serve --host 0.0.0.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,6 @@
 FROM jekyll/builder
-RUN jekyll serve
-EXPOSE 4000/tcp
+WORKDIR /usr/src/app
+COPY . .
+RUN gem install bundler
+RUN bundler install
+CMD [ "bundle", "exec", "jekyll", "serve" ]    

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@ FROM jekyll/jekyll
 WORKDIR /srv/
 RUN gem install bundler
 
-COPY . . # Note: content folder is copied, only to be replaced later.
+# Note: content folder is copied, only to be replaced later.
+COPY . .
 RUN chmod a+w Gemfile.lock
 RUN bundle install
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,4 @@
-FROM jekyll/builder
-WORKDIR /usr/src/app
+FROM jekyll/jekyll
 COPY . .
-RUN gem install bundler
-RUN bundler update --bundler
-RUN bundler install
-CMD [ "bundle", "exec", "jekyll", "serve" ]    
+RUN [ "bundle", "install", "--path", "vendor/bundle"]
+RUN [ "bundle", "exec", "jekyll", "serve" ]    

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,3 @@
 FROM jekyll/builder
 RUN jekyll serve
+EXPOSE 4000/tcp

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /srv/
 RUN gem install bundler
 
 COPY . .
-RUN ["chmod", "a+w", "Gemfile.lock"]
+RUN chmod a+w Gemfile.lock
 RUN bundle install
 
 EXPOSE 4000

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,5 +2,6 @@ FROM jekyll/builder
 WORKDIR /usr/src/app
 COPY . .
 RUN gem install bundler
+RUN bundler update --bundler
 RUN bundler install
 CMD [ "bundle", "exec", "jekyll", "serve" ]    

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,2 @@
 FROM jekyll/builder
+RUN jekyll serve

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,1 @@
+FROM jekyll/builder

--- a/run.sh
+++ b/run.sh
@@ -4,6 +4,9 @@ CONTENT_DIR="_apprenticeship"
 IMAGEID="apprenticeship_web"
 HOST_PORT=4000
 DOCKER_PORT=4000
+WORKDIR=/srv/ # docker WORKDIR
 
 docker build -t $IMAGEID .
-docker run -p $HOST_PORT:$DOCKER_PORT -v $(pwd)/$CONTENT_DIR:/srv/$CONTENT_DIR $IMAGEID
+docker run -p $HOST_PORT:$DOCKER_PORT \
+       -v $(pwd)/$CONTENT_DIR:$WORKDIR$CONTENT_DIR \
+       $IMAGEID

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,2 @@
+docker build -t apprenticeship_web .
+docker run -p 4000:4000 -v "$(pwd)"/_apprenticeship:/srv/_apprenticeship app_web

--- a/run.sh
+++ b/run.sh
@@ -1,2 +1,9 @@
-docker build -t apprenticeship_web .
-docker run -p 4000:4000 -v "$(pwd)"/_apprenticeship:/srv/_apprenticeship app_web
+#!/bin/sh
+
+CONTENT_DIR="_apprenticeship"
+IMAGEID="apprenticeship_web"
+HOST_PORT=4000
+DOCKER_PORT=4000
+
+docker build -t $IMAGEID .
+docker run -p $HOST_PORT:$DOCKER_PORT -v $(pwd)/$CONTENT_DIR:/srv/$CONTENT_DIR $IMAGEID

--- a/run.sh
+++ b/run.sh
@@ -4,9 +4,19 @@ CONTENT_DIR="_apprenticeship"
 IMAGEID="apprenticeship_web"
 HOST_PORT=4000
 DOCKER_PORT=4000
-WORKDIR=/srv/ # docker WORKDIR
+WORKDIR=/srv/
 
-docker build -t $IMAGEID .
-docker run -p $HOST_PORT:$DOCKER_PORT \
-       -v $(pwd)/$CONTENT_DIR:$WORKDIR$CONTENT_DIR \
-       $IMAGEID
+case $1 in
+    "build")
+	docker build -t $IMAGEID .
+	;;
+    "run")
+	docker run -p $HOST_PORT:$DOCKER_PORT \
+	       -v $(pwd)/$CONTENT_DIR:$WORKDIR$CONTENT_DIR \
+	       $IMAGEID
+	;;
+    *)
+	echo "Invalid usage!"
+	echo "To build the docker image, use: ./run.sh build"
+	echo "To run the docker image, use: ./run.sh run"
+esac


### PR DESCRIPTION
A Dockerfile and a shell script have been added to use for local development.
The Dockerfile installs Jekyll and it's dependencies. The shell script runs the docker commands to build a Docker image and then run it.
To build the Docker image, use:
`./run.sh build`
To run a Docker instance of the website, use:
`./run.sh run`

The folder `_apprenticeship` is mounted directly from the host, so that changes to the markdown files in the host trigger the website to be rebuilt by Jekyll in the running container.