### PR TITLE
Docker makefile local deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,17 @@
+# Run the blog locally, via nix
+
+The site can be built and run locally using nix.
+1) Make sure to have nix installed (see [nixos.org/nix](https://nixos.org/nix/)) and then 
+2) run `nix-shell default.nix` (or simply `nix-shell`) and you should have the blog 
+3) running locally at http://localhost:4000.
+
+# Run the blog locally, via Docker
+
+The site can be built and run locally using Docker.
+1) Run `make build` (or simply `make`) to build the docker image and then
+2) serve it locally using `make serve` and you should have the blog
+3) running locally at http://localhost:4000.
+
 # Icons
 
 Are you looking for the items that we are using on this page?

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
-# Run the blog locally, via nix
+# Run the blog locally
+## via nix
 
 The site can be built and run locally using nix.
 1) Make sure to have nix installed (see [nixos.org/nix](https://nixos.org/nix/)) and then 
 2) run `nix-shell default.nix` (or simply `nix-shell`) and you should have the blog 
 3) running locally at http://localhost:4000.
 
-# Run the blog locally, via Docker
+## via docker
 
 The site can be built and run locally using Docker.
 1) Run `make build` (or simply `make`) to build the docker image and then

--- a/_config.yml
+++ b/_config.yml
@@ -30,6 +30,7 @@ gems:
 exclude:
   - Gemfile
   - Gemfile.lock
+  - vendor
 
 collections:
   apprenticeship:

--- a/makefile
+++ b/makefile
@@ -11,5 +11,6 @@ serve:
 	docker run --rm \
 	--volume="$(PWD):/srv/jekyll" \
 	--volume="$(PWD)/vendor/bundle:/usr/local/bundle" \
+	-p 4000:4000 \
 	-it jekyll/jekyll:$(JEKYLL_VERSION) \
 	jekyll serve

--- a/makefile
+++ b/makefile
@@ -1,0 +1,15 @@
+SHELL = /bin/sh
+JEKYLL_VERSION = 3.8.5
+
+build:
+	docker run --rm \
+	--volume="$(PWD):/srv/jekyll" \
+	--volume="$(PWD)/vendor/bundle:/usr/local/bundle" \
+	-it jekyll/jekyll:$(JEKYLL_VERSION) \
+	jekyll build
+serve:
+	docker run --rm \
+	--volume="$(PWD):/srv/jekyll" \
+	--volume="$(PWD)/vendor/bundle:/usr/local/bundle" \
+	-it jekyll/jekyll:$(JEKYLL_VERSION) \
+	jekyll serve


### PR DESCRIPTION
To direct Jekyll to build the website in a docker container, use:

`make`

To serve the website in localhost, use:

`make serve`